### PR TITLE
Channel signals : tokio mpsc, tokio broadcast

### DIFF
--- a/examples/tokio-channels/Cargo.toml
+++ b/examples/tokio-channels/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tokio-channels"
+edition = "2021"
+license.workspace = true
+version.workspace = true
+
+
+[dependencies]
+floem = { path = "../..", features = ["tokio"] }
+tokio = { version = "1", features = ["time", "sync", "rt-multi-thread"] }

--- a/examples/tokio-channels/src/main.rs
+++ b/examples/tokio-channels/src/main.rs
@@ -1,0 +1,93 @@
+use floem::{ext_event::ChannelSignal, reactive::*};
+use floem::{prelude::*, taffy::FlexDirection};
+
+fn main() {
+    let runtime = tokio::runtime::Runtime::new().expect("Tokio runtime");
+
+    let (mpsc_tx, mpsc_rx) = tokio::sync::mpsc::channel::<i32>(16);
+    let (mpsc_unbound_tx, mpsc_unbound_rx) = tokio::sync::mpsc::unbounded_channel::<i32>();
+    let (broad_tx, broad_rx) = tokio::sync::broadcast::channel::<i32>(16);
+
+    // We must run floem app in context of tokio runtime, so that
+    // things like `tokio::spawn` will work.
+    // It is imperative to make sure that floem runs on the main thread.
+    runtime.block_on(async {
+        {
+            // channels will be closed after loop reaches its end
+
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
+
+            tokio::spawn(async move {
+                for i in 0..=8 {
+                    interval.tick().await;
+                    broad_tx.send(i).expect("send");
+                    mpsc_tx.send(i).await.expect("send");
+                    mpsc_unbound_tx.send(i).expect("send");
+                }
+            });
+        }
+
+        tokio::task::block_in_place(|| {
+            floem::launch(move || {
+                app_view(AppViewOpts {
+                    broad_rx,
+                    mpsc_rx,
+                    mpsc_unbound_rx,
+                })
+            })
+        })
+    });
+}
+
+struct AppViewOpts {
+    broad_rx: tokio::sync::broadcast::Receiver<i32>,
+    mpsc_rx: tokio::sync::mpsc::Receiver<i32>,
+    mpsc_unbound_rx: tokio::sync::mpsc::UnboundedReceiver<i32>,
+}
+
+fn app_view(opts: AppViewOpts) -> impl IntoView {
+    v_stack((
+        view_broadcast(opts.broad_rx),
+        view_mpsc(opts.mpsc_rx),
+        view_mpsc_unbound(opts.mpsc_unbound_rx),
+    ))
+    .style(|s| {
+        s.size_full()
+            .flex_direction(FlexDirection::Column)
+            .items_stretch()
+            .gap(30)
+            .padding(10)
+    })
+}
+
+fn view_broadcast(rx: tokio::sync::broadcast::Receiver<i32>) -> impl IntoView {
+    let signal0 = ChannelSignal::from(rx.resubscribe());
+    let signal1 = ChannelSignal::from(rx);
+
+    v_stack((
+        text("tokio broadcast receiver:").style(|s| s.font_bold()),
+        label(move || format!("orig  rx: {:?}", signal0.get())),
+        label(move || format!("resub rx: {:?}", signal1.get())),
+    ))
+    .style(|s| s.gap(10))
+}
+
+fn view_mpsc(rx: tokio::sync::mpsc::Receiver<i32>) -> impl IntoView {
+    let signal = ChannelSignal::from(rx);
+
+    v_stack((
+        text("tokio mpsc receiver:").style(|s| s.font_bold()),
+        label(move || format!("rx: {:?}", signal.get())),
+    ))
+    .style(|s| s.gap(10))
+}
+
+fn view_mpsc_unbound(rx: tokio::sync::mpsc::UnboundedReceiver<i32>) -> impl IntoView {
+    let signal = ChannelSignal::from(rx);
+
+    v_stack((
+        text("tokio unbounded mpsc receiver:").style(|s| s.font_bold()),
+        label(move || format!("{:?}", signal.get())),
+    ))
+    .style(|s| s.gap(10))
+}

--- a/reactive/src/lib.rs
+++ b/reactive/src/lib.rs
@@ -25,6 +25,7 @@ pub use effect::{
     batch, create_effect, create_stateful_updater, create_tracker, create_updater, untrack,
     SignalTracker,
 };
+pub use id::Id as ReactiveId;
 pub use memo::{create_memo, Memo};
 pub use read::{ReadSignalValue, SignalGet, SignalRead, SignalTrack, SignalWith};
 pub use scope::{as_child_of_current_scope, with_scope, Scope};

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -17,6 +17,9 @@ use crossbeam::channel::Receiver;
 #[cfg(not(feature = "crossbeam"))]
 use std::sync::mpsc::Receiver;
 
+mod channel_signal;
+pub use channel_signal::ChannelSignal;
+
 /// # SAFETY
 ///
 /// **DO NOT USE THIS** trigger except for when using with `create_ext_action` or when you guarantee that
@@ -161,83 +164,6 @@ pub fn update_signal_from_channel<T: Send + 'static>(
         }
         send(());
     });
-}
-
-pub fn create_signal_from_channel<T: Send + 'static>(rx: Receiver<T>) -> ReadSignal<Option<T>> {
-    let cx = Scope::new();
-    let trigger = with_scope(cx, ExtSendTrigger::new);
-
-    let channel_closed = cx.create_rw_signal(false);
-    let (read, write) = cx.create_signal(None);
-    let data = Arc::new(Mutex::new(VecDeque::new()));
-
-    {
-        let data = data.clone();
-        cx.create_effect(move |_| {
-            trigger.track();
-            while let Some(value) = data.lock().pop_front() {
-                write.set(value);
-            }
-
-            if channel_closed.get() {
-                cx.dispose();
-            }
-        });
-    }
-
-    let send = create_ext_action(cx, move |_| {
-        channel_closed.set(true);
-    });
-
-    std::thread::spawn(move || {
-        while let Ok(event) = rx.recv() {
-            data.lock().push_back(Some(event));
-            EXT_EVENT_HANDLER.add_trigger(trigger);
-        }
-        send(());
-    });
-
-    read
-}
-
-#[cfg(feature = "tokio")]
-pub fn create_signal_from_tokio_channel<T: Send + 'static>(
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<T>,
-) -> ReadSignal<Option<T>> {
-    let cx = Scope::new();
-    let trigger = with_scope(cx, ExtSendTrigger::new);
-
-    let channel_closed = cx.create_rw_signal(false);
-    let (read, write) = cx.create_signal(None);
-    let data = std::sync::Arc::new(std::sync::Mutex::new(VecDeque::new()));
-
-    {
-        let data = data.clone();
-        cx.create_effect(move |_| {
-            trigger.track();
-            while let Some(value) = data.lock().unwrap().pop_front() {
-                write.set(value);
-            }
-
-            if channel_closed.get() {
-                cx.dispose();
-            }
-        });
-    }
-
-    let send = create_ext_action(cx, move |_| {
-        channel_closed.set(true);
-    });
-
-    tokio::spawn(async move {
-        while let Some(event) = rx.recv().await {
-            data.lock().unwrap().push_back(Some(event));
-            crate::ext_event::register_ext_trigger(trigger);
-        }
-        send(());
-    });
-
-    read
 }
 
 #[cfg(feature = "futures")]

--- a/src/ext_event/channel_signal.rs
+++ b/src/ext_event/channel_signal.rs
@@ -203,7 +203,7 @@ impl<T: Send + 'static> From<crossbeam::channel::Receiver<T>> for ChannelSignal<
         let trigger = with_scope(cx, ExtSendTrigger::new);
         let channel_closed = cx.create_rw_signal(false);
         let (read, write) = cx.create_signal(None);
-        let data = Arc::new(Mutex::new(VecDeque::new()));
+        let data = Arc::new(parking_lot::Mutex::new(VecDeque::new()));
         {
             let data = data.clone();
             cx.create_effect(move |_| {

--- a/src/ext_event/channel_signal.rs
+++ b/src/ext_event/channel_signal.rs
@@ -1,0 +1,151 @@
+use parking_lot::Mutex;
+use std::{collections::VecDeque, sync::Arc};
+
+use crate::ext_event::{create_ext_action, ExtSendTrigger, EXT_EVENT_HANDLER};
+
+pub struct ChannelSignal<T>(floem_reactive::ReadSignal<Option<T>>);
+impl<T: std::clone::Clone> floem_reactive::SignalGet<Option<T>> for ChannelSignal<T> {
+    fn id(&self) -> floem_reactive::ReactiveId {
+        self.0.id()
+    }
+}
+impl<T> floem_reactive::SignalWith<Option<T>> for ChannelSignal<T> {
+    fn id(&self) -> floem_reactive::ReactiveId {
+        self.0.id()
+    }
+}
+impl<T> floem_reactive::SignalRead<Option<T>> for ChannelSignal<T> {
+    fn id(&self) -> floem_reactive::ReactiveId {
+        self.0.id()
+    }
+}
+impl<T> Copy for ChannelSignal<T> {}
+impl<T> Clone for ChannelSignal<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Eq for ChannelSignal<T> {}
+impl<T> PartialEq for ChannelSignal<T> {
+    fn eq(&self, other: &Self) -> bool {
+        pub use floem_reactive::SignalWith;
+        self.0.id() == other.0.id()
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<T: Send + 'static> From<tokio::sync::mpsc::UnboundedReceiver<T>> for ChannelSignal<T> {
+    fn from(mut rx: tokio::sync::mpsc::UnboundedReceiver<T>) -> Self {
+        use floem_reactive::*;
+        use std::collections::VecDeque;
+
+        use floem_reactive::{with_scope, Scope};
+
+        let cx = Scope::new();
+        let trigger = with_scope(cx, ExtSendTrigger::new);
+        let channel_closed = cx.create_rw_signal(false);
+        let (read, write) = cx.create_signal(None);
+        let data = std::sync::Arc::new(std::sync::Mutex::new(VecDeque::new()));
+        {
+            let data = data.clone();
+            cx.create_effect(move |_| {
+                trigger.track();
+                while let Some(value) = data.lock().unwrap().pop_front() {
+                    write.set(value);
+                }
+                if channel_closed.get() {
+                    cx.dispose();
+                }
+            });
+        }
+        let send = create_ext_action(cx, move |_| {
+            channel_closed.set(true);
+        });
+        tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                data.lock().unwrap().push_back(Some(event));
+                crate::ext_event::register_ext_trigger(trigger);
+            }
+            send(());
+        });
+        Self(read)
+    }
+}
+
+#[cfg(feature = "crossbeam")]
+impl<T: Send + 'static> From<crossbeam::channel::Receiver<T>> for ChannelSignal<T> {
+    fn from(rx: crossbeam::channel::Receiver<T>) -> Self {
+        use floem_reactive::*;
+        let cx = Scope::new();
+        let trigger = with_scope(cx, ExtSendTrigger::new);
+        let channel_closed = cx.create_rw_signal(false);
+        let (read, write) = cx.create_signal(None);
+        let data = Arc::new(Mutex::new(VecDeque::new()));
+        {
+            let data = data.clone();
+            cx.create_effect(move |_| {
+                trigger.track();
+                while let Some(value) = data.lock().pop_front() {
+                    write.set(value);
+                }
+                if channel_closed.get() {
+                    cx.dispose();
+                }
+            });
+        }
+        let send = create_ext_action(cx, move |_| {
+            channel_closed.set(true);
+        });
+        std::thread::spawn(move || {
+            while let Ok(event) = rx.recv() {
+                data.lock().push_back(Some(event));
+                EXT_EVENT_HANDLER.add_trigger(trigger);
+            }
+            send(());
+        });
+        Self(read)
+    }
+}
+
+impl<T: Send + 'static> From<std::sync::mpsc::Receiver<T>> for ChannelSignal<T> {
+    fn from(rx: std::sync::mpsc::Receiver<T>) -> Self {
+        use floem_reactive::*;
+        let cx = Scope::new();
+        let trigger = with_scope(cx, ExtSendTrigger::new);
+        let channel_closed = cx.create_rw_signal(false);
+        let (read, write) = cx.create_signal(None);
+        let data = Arc::new(Mutex::new(VecDeque::new()));
+        {
+            let data = data.clone();
+            cx.create_effect(move |_| {
+                trigger.track();
+                while let Some(value) = data.lock().pop_front() {
+                    write.set(value);
+                }
+                if channel_closed.get() {
+                    cx.dispose();
+                }
+            });
+        }
+        let send = create_ext_action(cx, move |_| {
+            channel_closed.set(true);
+        });
+        std::thread::spawn(move || {
+            while let Ok(event) = rx.recv() {
+                data.lock().push_back(Some(event));
+                EXT_EVENT_HANDLER.add_trigger(trigger);
+            }
+            send(());
+        });
+        Self(read)
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<T> std::ops::Deref for ChannelSignal<T> {
+    type Target = ReadSignal<Option<T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/src/ext_event/channel_signal.rs
+++ b/src/ext_event/channel_signal.rs
@@ -1,8 +1,43 @@
-use parking_lot::Mutex;
 use std::{collections::VecDeque, sync::Arc};
 
 use crate::ext_event::{create_ext_action, ExtSendTrigger, EXT_EVENT_HANDLER};
 
+/// A reactive resource which receives values from the channel.
+///
+/// `ChannelSignal` provides a way to reactively receive data from the channel,
+/// and does trigger a reactive update for each of the received values.
+///
+/// The signal will be updated once for every received value in the exact
+/// same order as they are being received from the channel, thus
+/// there is no guarantee that the `ChannelSignal` state is instantly
+/// consistent with the latest value sent to the channel.
+///
+/// When the `ChannelSignal` is created its state is `None`.
+///
+/// When the channel is closed the signal shall update up to the last
+/// received value and then its state will be set to `None`.
+///
+/// # Supported channel types
+///
+/// - `std::sync::mpsc::Receiver`
+///
+/// do not require additional features
+///
+/// - `tokio::sync::mpsc::Receiver`
+/// - `tokio::sync::mpsc::UnboundedReceiver`
+/// - `tokio::sync::broadcast::Receiver`
+///
+/// require `tokio` feature flag
+///
+/// - `crossbeam::channel::Receiver`
+///
+/// require `crossbeam` feature flag
+///
+/// # Concurrency
+///
+/// `ChannelSignal` handles received values in the exact same order as they are
+/// being _received_ by provided receiver without any further implications.
+///
 pub struct ChannelSignal<T>(floem_reactive::ReadSignal<Option<T>>);
 impl<T: std::clone::Clone> floem_reactive::SignalGet<Option<T>> for ChannelSignal<T> {
     fn id(&self) -> floem_reactive::ReactiveId {
@@ -34,41 +69,129 @@ impl<T> PartialEq for ChannelSignal<T> {
 }
 
 #[cfg(feature = "tokio")]
-impl<T: Send + 'static> From<tokio::sync::mpsc::UnboundedReceiver<T>> for ChannelSignal<T> {
-    fn from(mut rx: tokio::sync::mpsc::UnboundedReceiver<T>) -> Self {
+impl<T: Send + 'static> ChannelSignal<T> {
+    /// Create the `ChannelSignal` from a future, which shall write
+    /// values sequentially to the given buffer.
+    ///
+    /// This is useful for adpoting unsupported channel types, as well as
+    /// for any other asynchronously produced sequential data.
+    ///
+    /// Future must write values to the end of deque and register the trigger
+    /// after every write.
+    ///
+    /// The trigger should be registered after each push to the deque,
+    /// however it is not mandatory: trigger register shall lead to a series of
+    /// signal updates untill the decue is exhausted.
+    ///
+    /// # Example
+    ///
+    /// ```ignore ("requires tokio rt-multi-thread")
+    /// # use floem::ext_event::ChannelSignal;
+    /// # let seq = vec![1,2,3,4,5];
+    /// # let mut sequence = seq.into_iter();
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # rt.block_on(async {
+    /// // Requires tokio runtime context
+    /// ChannelSignal::from_async_sequential(move |queue, trigger|
+    ///     async move {
+    ///         while let Some(value) = sequence.next() {
+    ///             queue.lock()
+    ///                 .expect("ChannelSignal lock")
+    ///                 .push_back(value);
+    ///             floem::ext_event::register_ext_trigger(trigger);
+    ///         }
+    ///     }
+    /// );
+    /// # });
+    /// ```
+    pub fn from_async_sequential<Fut>(
+        channel: impl FnOnce(Arc<std::sync::Mutex<VecDeque<T>>>, ExtSendTrigger) -> Fut,
+    ) -> Self
+    where
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
         use floem_reactive::*;
         use std::collections::VecDeque;
 
-        use floem_reactive::{with_scope, Scope};
+        let (read, write) = with_scope(Scope::current(), || create_signal(None));
 
         let cx = Scope::new();
         let trigger = with_scope(cx, ExtSendTrigger::new);
         let channel_closed = cx.create_rw_signal(false);
-        let (read, write) = cx.create_signal(None);
         let data = std::sync::Arc::new(std::sync::Mutex::new(VecDeque::new()));
         {
             let data = data.clone();
             cx.create_effect(move |_| {
                 trigger.track();
                 while let Some(value) = data.lock().unwrap().pop_front() {
-                    write.set(value);
+                    write.set(Some(value));
                 }
                 if channel_closed.get() {
+                    write.set(None);
                     cx.dispose();
                 }
             });
         }
-        let send = create_ext_action(cx, move |_| {
+        let close = create_ext_action(cx, move |_| {
             channel_closed.set(true);
         });
+
+        let fut = channel(data.clone(), trigger);
         tokio::spawn(async move {
+            fut.await;
+            close(())
+        });
+
+        Self(read)
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<T: Send + 'static> From<tokio::sync::mpsc::UnboundedReceiver<T>> for ChannelSignal<T> {
+    fn from(mut rx: tokio::sync::mpsc::UnboundedReceiver<T>) -> Self {
+        Self::from_async_sequential(move |data, trigger| async move {
             while let Some(event) = rx.recv().await {
-                data.lock().unwrap().push_back(Some(event));
+                data.lock().unwrap().push_back(event);
                 crate::ext_event::register_ext_trigger(trigger);
             }
-            send(());
-        });
-        Self(read)
+        })
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<T: Send + 'static> From<tokio::sync::mpsc::Receiver<T>> for ChannelSignal<T> {
+    fn from(mut rx: tokio::sync::mpsc::Receiver<T>) -> Self {
+        Self::from_async_sequential(move |data, trigger| async move {
+            while let Some(event) = rx.recv().await {
+                data.lock().unwrap().push_back(event);
+                crate::ext_event::register_ext_trigger(trigger);
+            }
+        })
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<T: Send + Clone + 'static> From<tokio::sync::broadcast::Receiver<T>>
+    for ChannelSignal<Result<T, tokio::sync::broadcast::error::RecvError>>
+{
+    fn from(mut rx: tokio::sync::broadcast::Receiver<T>) -> Self {
+        Self::from_async_sequential(move |data, trigger| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        data.lock().unwrap().push_back(Ok(event));
+                        crate::ext_event::register_ext_trigger(trigger);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
+                    Err(e) => {
+                        data.lock().unwrap().push_back(Err(e));
+                        crate::ext_event::register_ext_trigger(trigger);
+                    }
+                }
+            }
+        })
     }
 }
 
@@ -114,12 +237,12 @@ impl<T: Send + 'static> From<std::sync::mpsc::Receiver<T>> for ChannelSignal<T> 
         let trigger = with_scope(cx, ExtSendTrigger::new);
         let channel_closed = cx.create_rw_signal(false);
         let (read, write) = cx.create_signal(None);
-        let data = Arc::new(Mutex::new(VecDeque::new()));
+        let data = Arc::new(std::sync::Mutex::new(VecDeque::new()));
         {
             let data = data.clone();
             cx.create_effect(move |_| {
                 trigger.track();
-                while let Some(value) = data.lock().pop_front() {
+                while let Some(value) = data.lock().unwrap().pop_front() {
                     write.set(value);
                 }
                 if channel_closed.get() {
@@ -132,7 +255,7 @@ impl<T: Send + 'static> From<std::sync::mpsc::Receiver<T>> for ChannelSignal<T> 
         });
         std::thread::spawn(move || {
             while let Ok(event) = rx.recv() {
-                data.lock().push_back(Some(event));
+                data.lock().unwrap().push_back(Some(event));
                 EXT_EVENT_HANDLER.add_trigger(trigger);
             }
             send(());
@@ -143,7 +266,7 @@ impl<T: Send + 'static> From<std::sync::mpsc::Receiver<T>> for ChannelSignal<T> 
 
 #[cfg(feature = "tokio")]
 impl<T> std::ops::Deref for ChannelSignal<T> {
-    type Target = ReadSignal<Option<T>>;
+    type Target = floem_reactive::ReadSignal<Option<T>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0


### PR DESCRIPTION
[link to the discord thread](https://discord.com/channels/946858761413328946/1421515798664450100)

## Breaking changes

> not sure on this one

Currently when receiver could not fetch more data the scope created for `ChannelSignal` gets disposed. I _believe_ that this may lead to unexpected panic on the UI side because there is no implied way to track if channel is about to close or was already closed.

Thus it is proposed to create data signal in the `Scope::current` rather then in scope created for `ChannelSignal` and set the signal value to `None` when receiver is exhausted/closed/whatever.

## Additive features

*PR proposes following non-breaking additive changes*:

0. implement `From<tokio::sync::mpsc::Receiver<T>>`
    for `ChannelSignal<T>`
1. [implement](#implementation-for-broadcast) `From<tokio::sync::broadcast::Receiver<T>>`
    for `ChannelSignal<Result<T, tokio::sync::broadcast::error::RecvError>>`
2. Create an example showing tokio signals
3. [expose](#expose-async-sequential) method `from_async_sequential`, which abstracts the way of constructing `ChannelSignal`

### Implementation for broadcast

When receiving a value from `broadcast` signal there are two present variants of error: `RecvError::Closed` and `RecvError::Lagged(..)`.

Since the `ChannelSignal` handles close of channel, but has no defined contract for handling other types of non-value receivings, it is proposed that `ChannelSignal` has the type of `Result<T, tokio::sync::broadcast::error::RecvError>`.

Proposed implementation handles `RecvError::Closed` as a close by breaking receiver loop, but does propagate any other variants of errors to the queue.

### Expose async sequential

Since all currently implemented tokio channel receivers share the same synchronization logic, the `from_async_sequential` method was introduced. That method handles reactive updates and fetches values form deque.

It is proposed to also make this method public, so that developer may adopt other sequential sources of data without need to implement them on floem side.
